### PR TITLE
Add Debian packaging

### DIFF
--- a/.github/scripts/make_debian.sh
+++ b/.github/scripts/make_debian.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+VERSION=$(git describe)
+SERVICE=downlink_service
+CONF_PATH=./pkg/settings-template.toml
+
+# install fpm
+sudo apt update
+sudo apt install --yes ruby
+sudo gem install fpm -v 1.14.2 # current as of 2022-11-08
+
+# XXX HACK fpm won't let us mark a config file unless
+# it exists at the specified path
+mkdir -p /opt/${SERVICE}/etc
+touch /opt/${SERVICE}/etc/settings.toml
+
+fpm -n ${SERVICE} \
+    -v "${VERSION}" \
+    -s dir \
+    -t deb \
+    --deb-systemd "/tmp/${SERVICE}.service" \
+    --before-install "/tmp/${SERVICE}-preinst" \
+    --after-install "/tmp/${SERVICE}-postinst" \
+    --after-remove "/tmp/${SERVICE}-postrm" \
+    --deb-no-default-config-files \
+    --deb-systemd-enable \
+    --deb-systemd-auto-start \
+    --deb-systemd-restart-after-upgrade \
+    --deb-user helium \
+    --deb-group helium \
+    --config-files /opt/${SERVICE}/etc/settings.toml \
+    target/release/${SERVICE}=/opt/${SERVICE}/bin/${SERVICE} \
+    $CONF_PATH=/opt/${SERVICE}/etc/settings-example.toml

--- a/.github/scripts/packagecloud_upload.sh
+++ b/.github/scripts/packagecloud_upload.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd $GITHUB_WORKSPACE
+
+for deb in *.deb
+do
+    curl -u "${PACKAGECLOUD_API_KEY}:" \
+         -F "package[distro_version_id]=210" \
+         -F "package[package_file]=@$deb" \
+         https://packagecloud.io/api/v1/repos/helium/downlink_service/packages.json
+done

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+    tags: [ '*' ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+          override: true
+          components: clippy, rustfmt
+
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow/action@0.5.0
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Build
+        run: cargo build --release
+
+      - name: Check Formatting
+        run: cargo fmt -- --check
+
+      - name: Clippy
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --release -- -Dclippy::all
+
+      - name: Run tests
+        run: cargo test -r
+
+      - name: Debian Packaging
+        run: |
+          chmod +x ./.github/scripts/make_debian.sh
+          ./.github/scripts/make_debian.sh
+
+      - name: PackageCloud Upload
+        env:
+          PACKAGECLOUD_API_KEY: ${{ secrets.PACKAGECLOUD_API_KEY }}
+        run: |
+          chmod +x ./.github/scripts/packagecloud_upload.sh
+          ./.github/scripts/packagecloud_upload.sh

--- a/deb/downlink_service-postinst
+++ b/deb/downlink_service-postinst
@@ -1,0 +1,2 @@
+# add to /usr/local/bin so it appears in path
+ln -s /opt/downlink_service/bin/downlink_service /usr/local/bin/downlink_service || true

--- a/deb/downlink_service-postrm
+++ b/deb/downlink_service-postrm
@@ -1,0 +1,1 @@
+rm -f /usr/local/bin/downlink_service

--- a/deb/downlink_service-preinst
+++ b/deb/downlink_service-preinst
@@ -1,0 +1,2 @@
+# add system user for file ownership and systemd user, if not exists
+useradd --system --home-dir /opt/helium --create-home helium || true

--- a/deb/downlink_service.service
+++ b/deb/downlink_service.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=downlink_service
+After=network.target
+StartLimitInterval=60
+StartLimitBurst=3
+
+[Service]
+Type=simple
+ExecStart=/opt/downlink_service/bin/downlink_service -c /opt/downlink_service/etc/settings.toml
+User=helium
+PIDFile=/var/run/downlink_service
+Restart=always
+RestartSec=15
+WorkingDirectory=/opt/downlink_service
+
+### Remove default limits from a few important places:
+LimitNOFILE=infinity
+LimitNPROC=infinity
+TasksMax=infinity
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Pulled together from https://github.com/helium/helium-packet-router/pull/17
and https://github.com/helium/oracles/blob/main/.github/workflows/rust.yml

I'm still unsure about `CONF_PATH` in `make_debian.sh`.
In Packet-Router there are many more hook files, I chose to go with only those present in the oracles repo.