### PR TITLE
Fix url typo

### DIFF
--- a/.github/scripts/make_debian.sh
+++ b/.github/scripts/make_debian.sh
@@ -67,7 +67,7 @@ run_fpm()
     mkdir -p /opt/downlink_service/etc
     touch /opt/downlink_service/etc/settings.toml
 
-    fpm -n downlink_service \
+    fpm -n downlink-service \
         -v "${VERSION}" \
         -s dir \
         -t deb \
@@ -105,5 +105,5 @@ do
     curl -u "${PACKAGECLOUD_API_KEY}:" \
          -F "package[distro_version_id]=210" \
          -F "package[package_file]=@$deb" \
-         https://packagecloud.io/api/v1/repos/helium/package_router/packages.json
+         https://packagecloud.io/api/v1/repos/helium/packet_router/packages.json
 done


### PR DESCRIPTION
Problem to solve: A typo in the packagecloud URL stopped the debian package from being uploaded successfully (even though the build technically 'succeeded')